### PR TITLE
try to fix get_transfer

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -70,13 +70,13 @@ func (c *WalletClient) GetTransferByTxId(txid string) (Transfer, error) {
 	}
 	return rep.Trade, nil
 }
-func (c *WalletClient) IncomingTransfers(transferType string) (Transfer, error) {
+func (c *WalletClient) IncomingTransfers(transferType string) ([]IncomingTransfer, error) {
 	req := struct {
 		TransferType string `json:"transfer_type"`
 	}{
 		transferType,
 	}
-	var rep Transfer
+	var rep []IncomingTransfer
 	if err := c.Wallet("incoming_transfers", req, &rep); err != nil {
 		return rep, err
 	}

--- a/wallet.go
+++ b/wallet.go
@@ -49,8 +49,8 @@ func (c *WalletClient) TransferSplit(req TransferInput) (Transfer, error) {
 	return rep, nil
 }
 
-func (c *WalletClient) GetTransfers(req GetTransferInput) (Transfer, error) {
-	var rep Transfer
+func (c *WalletClient) GetTransfers(req GetTransferInput) (TransferResponse, error) {
+	var rep TransferResponse
 	if err := c.Wallet("get_transfers", req, &rep); err != nil {
 		return rep, err
 	}

--- a/wallet.go
+++ b/wallet.go
@@ -70,13 +70,13 @@ func (c *WalletClient) GetTransferByTxId(txid string) (Transfer, error) {
 	}
 	return rep.Trade, nil
 }
-func (c *WalletClient) IncomingTransfers(transferType string) ([]IncomingTransfer, error) {
+func (c *WalletClient) IncomingTransfers(transferType string) (IncomingTransferResponse, error) {
 	req := struct {
 		TransferType string `json:"transfer_type"`
 	}{
 		transferType,
 	}
-	var rep []IncomingTransfer
+	var rep IncomingTransferResponse
 	if err := c.Wallet("incoming_transfers", req, &rep); err != nil {
 		return rep, err
 	}

--- a/wstruct.go
+++ b/wstruct.go
@@ -63,23 +63,15 @@ type TransferSplit struct {
 	TxKeyList  []string `json:"tx_key_list"`
 }
 
-// type Transfer struct {
-// 	Amount    uint   `json:"amount"`
-// 	Fee       uint   `json:"fee"`
-// 	Height    uint   `json:"height"`
-// 	Note      string `json:"note"`
-// 	PaymentId string `json:"payment_id"`
-// 	Timestamp uint   `json:"timestamp"`
-// 	Txid      string `json:"txid"`
-// 	Type      string `json:"type"`
-// }
-
 type IncomingTransfer struct {
 	Amount      uint64 `json:"amount,omitempty"`
 	Spent       bool   `json:"spent,omitempty"`
 	GlobalIndex uint64 `json:"global_index,omitempty"`
 	TxHash      string `json:"tx_hash,omitempty"`
 	TxSize      uint64 `json:"tx_size,omitempty"`
+}
+type IncomingTransferResponse struct {
+	Transfers []IncomingTransfer `json:"transfers"`
 }
 
 /***************************************/

--- a/wstruct.go
+++ b/wstruct.go
@@ -33,18 +33,26 @@ type Destination struct {
 	Address string `json:"address"`
 }
 
-type Transfer struct {
-	Fee    uint   `json:"fee,omitempty"`
-	TxHash string `json:"tx_hash,omitempty"`
-	TxKey  string `json:"tx_key,omitempty"`
+type TransferResponse struct {
+	In      []Transfer `json:"in, omitempty"`
+	Out     []Transfer `json:"out, omitempty"`
+	Pending []Transfer `json:"pending, omitempty"`
+	Failed  []Transfer `json:"failed, omitempty"`
+	Pool    []Transfer `json:"pool, omitempty"`
+}
 
-	Amount    uint64 `json:"amount,omitempty"`
-	Height    uint64 `json:"height,omitempty"`
-	Note      string `json:"note,omitempty"`
-	PaymentId string `json:"payment_id,omitempty"`
-	Timestamp int64  `json:"timestamp,omitempty"`
-	Txid      string `json:"txid,omitempty"`
-	Type      string `json:"type,omitempty"`
+type Transfer struct {
+	Fee          uint          `json:"fee,omitempty"`
+	TxHash       string        `json:"tx_hash,omitempty"`
+	TxKey        string        `json:"tx_key,omitempty"`
+	Destinations []Destination `json:"destinations,omitempty"`
+	Amount       uint64        `json:"amount,omitempty"`
+	Height       uint64        `json:"height,omitempty"`
+	Note         string        `json:"note,omitempty"`
+	PaymentID    string        `json:"payment_id,omitempty"`
+	Timestamp    int64         `json:"timestamp,omitempty"`
+	Txid         string        `json:"txid,omitempty"`
+	Type         string        `json:"type,omitempty"`
 }
 
 type TransferSplit struct {

--- a/wstruct.go
+++ b/wstruct.go
@@ -34,11 +34,11 @@ type Destination struct {
 }
 
 type TransferResponse struct {
-	In      []Transfer `json:"in, omitempty"`
-	Out     []Transfer `json:"out, omitempty"`
-	Pending []Transfer `json:"pending, omitempty"`
-	Failed  []Transfer `json:"failed, omitempty"`
-	Pool    []Transfer `json:"pool, omitempty"`
+	In      []Transfer `json:"in,omitempty"`
+	Out     []Transfer `json:"out,omitempty"`
+	Pending []Transfer `json:"pending,omitempty"`
+	Failed  []Transfer `json:"failed,omitempty"`
+	Pool    []Transfer `json:"pool,omitempty"`
 }
 
 type Transfer struct {
@@ -74,7 +74,12 @@ type TransferSplit struct {
 // 	Type      string `json:"type"`
 // }
 
-type IncomingTransfers struct {
+type IncomingTransfer struct {
+	Amount      uint64 `json:"amount,omitempty"`
+	Spent       bool   `json:"spent,omitempty"`
+	GlobalIndex uint64 `json:"global_index,omitempty"`
+	TxHash      string `json:"tx_hash,omitempty"`
+	TxSize      uint64 `json:"tx_size,omitempty"`
 }
 
 /***************************************/


### PR DESCRIPTION
fixing #1 , now gets the requested transactions. ~~non-requested transactions still show up as empty arrays, probably something to do with omitempty not working for null like it does with empty arrays.~~

both get_transfer and incoming_transfers should work as expected now, IncomingTransfers returns struct IncomingTransferResponse that contains an array with the transfers while GetTransfers returns the requested type of transfers and omits other ones in JSON.